### PR TITLE
New states for deletion confirmation dialog

### DIFF
--- a/app/src/main/java/ru/whoame/recogniser/ui/dialog/DeleteRecognisedItemDialog.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/dialog/DeleteRecognisedItemDialog.kt
@@ -2,13 +2,12 @@ package ru.whoame.recogniser.ui.dialog
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -17,73 +16,143 @@ import org.koin.core.parameter.parametersOf
 import ru.whoame.recogniser.R
 import ru.whoame.recogniser.model.RecognisedObject
 import ru.whoame.recogniser.ui.DarkLightPreviews
+import ru.whoame.recogniser.ui.dialog.state.model.DeleteRecognisedItemUiState
 import ru.whoame.recogniser.ui.theme.RecogniserTheme
+import ru.whoame.recogniser.utils.format
 
 @Composable
 fun DeleteRecognisedItemDialog(
-    item: RecognisedObject,
-    onDismissRequest: () -> Unit,
-    viewModel: DeleteRecognisedItemViewModel = koinViewModel { parametersOf(item) },
+  item: RecognisedObject,
+  onDismissRequest: (Boolean) -> Unit,
+  viewModel: DeleteRecognisedItemViewModel = koinViewModel { parametersOf(item) },
 ) {
-    val state by viewModel.uiStateFlow.collectAsStateWithLifecycle()
+  val state by viewModel.uiStateFlow.collectAsStateWithLifecycle()
 
-    DeleteRecognisedItemDialogStateless(
-        name = state.itemName,
-        isLoading = state.isLoading,
-        onConfirmRequest = { viewModel.confirm() },
-        onDismissRequest = onDismissRequest,
-    )
+  DeleteRecognisedItemDialogStateless(
+    icon = state.icon,
+    title = state.title.format(),
+    message = state.message?.format(),
+    dismissButtonText = state.dismissText?.format(),
+    isConfirmVisible = state.isConfirmVisible,
+    isLoading = state.isLoading,
+    onConfirmRequest = viewModel::confirm,
+    onDismissRequest = { onDismissRequest.invoke(state.isItemDeleted) },
+  )
 }
 
 @Composable
 private fun DeleteRecognisedItemDialogStateless(
-    name: String,
-    isLoading: Boolean,
-    onConfirmRequest: () -> Unit,
-    onDismissRequest: () -> Unit,
+  icon: DeleteRecognisedItemUiState.IconModel?,
+  title: String,
+  message: String?,
+  dismissButtonText: String?,
+  isConfirmVisible: Boolean,
+  isLoading: Boolean,
+  onConfirmRequest: () -> Unit,
+  onDismissRequest: () -> Unit,
 ) = AlertDialog(
-    title = {
-        Text(
-            text = stringResource(R.string.delete_recognised_item_dialog_title),
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    },
-    text = {
-        Text(stringResource(R.string.delete_recognised_item_dialog_text, name))
-    },
-    onDismissRequest = {
-        if (!isLoading) onDismissRequest.invoke()
-    },
-    dismissButton = {
-        if (!isLoading) {
-            Text(
-                text = stringResource(R.string.action_cancel),
-                modifier = Modifier.clickable(onClick = onDismissRequest),
-            )
-        }
-    },
-    confirmButton = {
-        if (!isLoading) {
-            Text(
-                text = stringResource(R.string.action_delete),
-                color = MaterialTheme.colorScheme.error,
-                modifier = Modifier.clickable(onClick = onConfirmRequest),
-            )
-        } else {
-            CircularProgressIndicator()
-        }
-    },
+  icon = {
+    icon?.let { value ->
+      Icon(
+        imageVector = value.vector,
+        contentDescription = null,
+        tint = value.tint,
+        modifier = Modifier.size(dimensionResource(R.dimen.delete_item_dialog_icon_size)),
+      )
+    }
+  },
+  title = {
+    Text(
+      text = title,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.fillMaxWidth(),
+    )
+  },
+  text = {
+    message?.let { value ->
+      Text(value)
+    }
+  },
+  onDismissRequest = {
+    if (!isLoading) onDismissRequest.invoke()
+  },
+  dismissButton = {
+    dismissButtonText?.let { value ->
+      Text(
+        text = value,
+        modifier = Modifier.clickable(onClick = onDismissRequest),
+      )
+    }
+  },
+  confirmButton = {
+    if (isLoading) {
+      CircularProgressIndicator()
+    } else if (isConfirmVisible) {
+      Text(
+        text = stringResource(R.string.action_delete),
+        color = MaterialTheme.colorScheme.error,
+        modifier = Modifier.clickable(onClick = onConfirmRequest),
+      )
+    }
+  },
 )
 
 @DarkLightPreviews
 @Composable
 private fun Preview() = RecogniserTheme {
-    DeleteRecognisedItemDialogStateless("One", false, {}, {})
+  DeleteRecognisedItemDialogStateless(
+    icon = null,
+    title = "Title",
+    message = "Message",
+    dismissButtonText = "Cancel",
+    isConfirmVisible = true,
+    isLoading = false,
+    onConfirmRequest = {},
+    onDismissRequest = {},
+  )
 }
 
 @DarkLightPreviews
 @Composable
 private fun LoadingPreview() = RecogniserTheme {
-    DeleteRecognisedItemDialogStateless("One", true, {}, {})
+  DeleteRecognisedItemDialogStateless(
+    icon = null,
+    title = "Title",
+    message = "Message",
+    dismissButtonText = null,
+    isConfirmVisible = true,
+    isLoading = false,
+    onConfirmRequest = {},
+    onDismissRequest = {},
+  )
+}
+
+@DarkLightPreviews
+@Composable
+private fun ErrorPreview() = RecogniserTheme {
+  DeleteRecognisedItemDialogStateless(
+    icon = DeleteRecognisedItemUiState.IconModel.Error(),
+    title = "Title",
+    message = "Message",
+    dismissButtonText = "Done",
+    isConfirmVisible = false,
+    isLoading = false,
+    onConfirmRequest = {},
+    onDismissRequest = {},
+  )
+}
+
+@DarkLightPreviews
+@Composable
+private fun DonePreview() = RecogniserTheme {
+  DeleteRecognisedItemDialogStateless(
+    icon = DeleteRecognisedItemUiState.IconModel.Done(),
+    title = "Title",
+    message = "Message",
+    dismissButtonText = "Cancel",
+    isConfirmVisible = false,
+    isLoading = false,
+    onConfirmRequest = {},
+    onDismissRequest = {},
+  )
 }

--- a/app/src/main/java/ru/whoame/recogniser/ui/dialog/state/factory/DeleteRecognisedItemStateFactory.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/dialog/state/factory/DeleteRecognisedItemStateFactory.kt
@@ -1,16 +1,55 @@
 package ru.whoame.recogniser.ui.dialog.state.factory
 
+import ru.whoame.recogniser.R
 import ru.whoame.recogniser.ui.dialog.state.model.DeleteRecognisedItemState
 import ru.whoame.recogniser.ui.dialog.state.model.DeleteRecognisedItemUiState
-import ru.whoame.recogniser.utils.isLoading
+import ru.whoame.recogniser.utils.Resource
+import ru.whoame.recogniser.utils.toStringArgs
 import ru.whoame.state_machine.contract.BaseStateFactory
 
 class DeleteRecognisedItemStateFactory :
-    BaseStateFactory<DeleteRecognisedItemState, DeleteRecognisedItemUiState> {
+  BaseStateFactory<DeleteRecognisedItemState, DeleteRecognisedItemUiState> {
 
-    override fun convert(state: DeleteRecognisedItemState) = DeleteRecognisedItemUiState(
-        itemName = state.item.title,
-        isLoading = state.deleteRequest?.isLoading() ?: false,
+  override fun convert(state: DeleteRecognisedItemState): DeleteRecognisedItemUiState = when (state.deleteRequest) {
+    is Resource.Loading -> DeleteRecognisedItemUiState(
+      icon = null,
+      title = R.string.delete_recognised_item_dialog_title.toStringArgs(),
+      message = R.string.delete_recognised_item_dialog_text.toStringArgs(state.item.title),
+      dismissText = null,
+      isConfirmVisible = false,
+      isLoading = true,
+      isItemDeleted = false,
     )
+
+    is Resource.Data -> DeleteRecognisedItemUiState(
+      icon = DeleteRecognisedItemUiState.IconModel.Done(),
+      title = R.string.delete_recognised_item_dialog_success_title.toStringArgs(),
+      message = null,
+      dismissText = R.string.action_done.toStringArgs(),
+      isConfirmVisible = false,
+      isLoading = false,
+      isItemDeleted = true,
+    )
+
+    is Resource.Error -> DeleteRecognisedItemUiState(
+      icon = DeleteRecognisedItemUiState.IconModel.Error(),
+      title = R.string.delete_recognised_item_dialog_error_title.toStringArgs(),
+      message = R.string.default_error.toStringArgs(),
+      dismissText = R.string.action_cancel.toStringArgs(),
+      isConfirmVisible = false,
+      isLoading = false,
+      isItemDeleted = false,
+    )
+
+    null -> DeleteRecognisedItemUiState(
+      icon = null,
+      title = R.string.delete_recognised_item_dialog_title.toStringArgs(),
+      message = R.string.delete_recognised_item_dialog_text.toStringArgs(state.item.title),
+      dismissText = R.string.action_cancel.toStringArgs(),
+      isConfirmVisible = true,
+      isLoading = false,
+      isItemDeleted = false,
+    )
+  }
 
 }

--- a/app/src/main/java/ru/whoame/recogniser/ui/dialog/state/handler/DeleteRecognisedItemDomainEventHandler.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/dialog/state/handler/DeleteRecognisedItemDomainEventHandler.kt
@@ -5,24 +5,21 @@ import kotlinx.coroutines.flow.map
 import ru.whoame.recogniser.data.repository.RecognisedObjectRepository
 import ru.whoame.recogniser.ui.dialog.state.model.DeleteRecognisedItemDomainEvent
 import ru.whoame.recogniser.ui.dialog.state.model.DeleteRecognisedItemState
-import ru.whoame.recogniser.utils.Resource
 import ru.whoame.state_machine.handler.BaseDomainEventHandler
 
 class DeleteRecognisedItemDomainEventHandler(
-    private val repository: RecognisedObjectRepository,
+  private val repository: RecognisedObjectRepository,
 ) : BaseDomainEventHandler<DeleteRecognisedItemState, Nothing, DeleteRecognisedItemDomainEvent>() {
 
-    override fun handleEvent(event: DeleteRecognisedItemDomainEvent): Flow<*> = when (event) {
-        is DeleteRecognisedItemDomainEvent.Delete -> delete()
-    }
+  override fun handleEvent(event: DeleteRecognisedItemDomainEvent): Flow<*> = when (event) {
+    is DeleteRecognisedItemDomainEvent.Delete -> delete()
+  }
 
-    private fun delete() = repository.delete(state.item.id)
-        .map { resource ->
-            if (resource !is Resource.Data) {
-                reduceState { state ->
-                    state.copy(deleteRequest = resource)
-                }
-            }
-        }
+  private fun delete() = repository.delete(state.item.id)
+    .map { resource ->
+      reduceState { state ->
+        state.copy(deleteRequest = resource)
+      }
+    }
 
 }

--- a/app/src/main/java/ru/whoame/recogniser/ui/dialog/state/model/DeleteRecognisedItemUiState.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/dialog/state/model/DeleteRecognisedItemUiState.kt
@@ -1,9 +1,41 @@
 package ru.whoame.recogniser.ui.dialog.state.model
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Done
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import ru.whoame.recogniser.ui.theme.SuccessGreen
+import ru.whoame.recogniser.ui.theme.errorLight
+import ru.whoame.recogniser.utils.StringArgs
 
 @Immutable
 data class DeleteRecognisedItemUiState(
-    val itemName: String,
-    val isLoading: Boolean,
-)
+  val icon: IconModel?,
+  val title: StringArgs,
+  val message: StringArgs?,
+  val dismissText: StringArgs?,
+  val isConfirmVisible: Boolean,
+  val isLoading: Boolean,
+  val isItemDeleted: Boolean,
+) {
+
+  sealed interface IconModel {
+
+    val vector: ImageVector
+    val tint: Color
+
+    data class Done(
+      override val vector: ImageVector = Icons.Default.Done,
+      override val tint: Color = SuccessGreen,
+    ) : IconModel
+
+    data class Error(
+      override val vector: ImageVector = Icons.Default.Close,
+      override val tint: Color = errorLight,
+    ) : IconModel
+
+  }
+
+}

--- a/app/src/main/java/ru/whoame/recogniser/ui/screen/recognisedlist/RecognisedListScreen.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/screen/recognisedlist/RecognisedListScreen.kt
@@ -90,7 +90,7 @@ private fun RecognisedListScreenStateless(
   when {
     isError -> ImageWithTitleAndMessageColumn(
       painter = rememberVectorPainter(Icons.Default.ErrorOutline),
-      title = stringResource(R.string.recognised_object_list_empty_title),
+      title = stringResource(R.string.default_error),
       message = stringResource(R.string.recognised_object_list_error_message),
       modifier = Modifier.padding(paddingMedium),
     )

--- a/app/src/main/java/ru/whoame/recogniser/ui/screen/recognisedlist/RecognisedListViewModel.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/screen/recognisedlist/RecognisedListViewModel.kt
@@ -30,8 +30,8 @@ class RecognisedListViewModel(
     ListScreenUiEvent.DeleteClick(id)
   }
 
-  fun dismissDeleteDialog() = launchEvent {
-    ListScreenUiEvent.DismissDeleteDialog
+  fun dismissDeleteDialog(isItemDeleted: Boolean) = launchEvent {
+    ListScreenUiEvent.DismissDeleteDialog(isItemDeleted)
   }
 
 }

--- a/app/src/main/java/ru/whoame/recogniser/ui/screen/recognisedlist/state/handler/ListScreenUiEventHandler.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/screen/recognisedlist/state/handler/ListScreenUiEventHandler.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import ru.whoame.recogniser.ui.screen.recognisedlist.state.model.ListScreenDomainEvent
 import ru.whoame.recogniser.ui.screen.recognisedlist.state.model.ListScreenState
 import ru.whoame.recogniser.ui.screen.recognisedlist.state.model.ListScreenUiEvent
+import ru.whoame.recogniser.utils.filter
 import ru.whoame.recogniser.utils.flowOf
 import ru.whoame.recogniser.utils.valueOrNull
 import ru.whoame.state_machine.handler.BaseUiEventHandler
@@ -14,7 +15,7 @@ class ListScreenUiEventHandler :
   override fun handleEvent(event: ListScreenUiEvent): Flow<*> = when (event) {
     is ListScreenUiEvent.ItemClick -> flowOf { itemClick(event.id) }
     is ListScreenUiEvent.DeleteClick -> flowOf { deleteClick(event.id) }
-    is ListScreenUiEvent.DismissDeleteDialog -> flowOf { dismissDeleteDialog() }
+    is ListScreenUiEvent.DismissDeleteDialog -> flowOf { dismissDeleteDialog(event.isItemDeleted) }
   }
 
   private suspend fun itemClick(id: Long?) = reduceState { state ->
@@ -29,8 +30,13 @@ class ListScreenUiEventHandler :
       }
     }
 
-  private suspend fun dismissDeleteDialog() = reduceState {
-    state.copy(itemToDelete = null)
+  private suspend fun dismissDeleteDialog(isItemDeleted: Boolean) = reduceState { state ->
+    val newList = if (isItemDeleted) {
+      state.list.filter { item -> item.id != state.itemToDelete?.id }
+    } else {
+      state.list
+    }
+    state.copy(list = newList, itemToDelete = null)
   }
 
 }

--- a/app/src/main/java/ru/whoame/recogniser/ui/screen/recognisedlist/state/model/ListScreenUiEvent.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/screen/recognisedlist/state/model/ListScreenUiEvent.kt
@@ -6,6 +6,6 @@ sealed interface ListScreenUiEvent {
 
   data class DeleteClick(val id: Long) : ListScreenUiEvent
 
-  object DismissDeleteDialog : ListScreenUiEvent
+  data class DismissDeleteDialog(val isItemDeleted: Boolean) : ListScreenUiEvent
 
 }

--- a/app/src/main/java/ru/whoame/recogniser/ui/theme/Color.kt
+++ b/app/src/main/java/ru/whoame/recogniser/ui/theme/Color.kt
@@ -75,3 +75,4 @@ val surfaceContainerHighDark = Color(0xFF262B2E)
 val surfaceContainerHighestDark = Color(0xFF313539)
 
 val Transparent = Color(0x00FFFFFF)
+val SuccessGreen = Color(0xFF4BB543)

--- a/app/src/main/java/ru/whoame/recogniser/utils/StringArgs.kt
+++ b/app/src/main/java/ru/whoame/recogniser/utils/StringArgs.kt
@@ -1,0 +1,46 @@
+package ru.whoame.recogniser.utils
+
+/**
+ * Represents a string value that can be resolved in two ways:
+ * either from a static [CharSequence] or from an Android string resource with format arguments.
+ * This sealed interface provides a type-safe way to handle different string sources.
+ **/
+sealed interface StringArgs
+
+/**
+ * Represents a string that is defined as an Android resource.
+ *
+ * @property resourceId The ID of the string resource (e.g., `R.string.example`).
+ * @property args The optional format arguments to be used with the string resource.
+ **/
+data class ResourceArgs(
+  val resourceId: Int,
+  val args: Array<Any> = emptyArray(),
+) : StringArgs {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as ResourceArgs
+
+    if (resourceId != other.resourceId) return false
+    if (!args.contentEquals(other.args)) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = resourceId
+    result = 31 * result + args.contentHashCode()
+    return result
+  }
+
+}
+
+/**
+ * Represents a string that is provided as a direct [CharSequence].
+ *
+ * @property value The concrete string value.
+ **/
+data class CharSequenceArgs(val value: CharSequence) : StringArgs

--- a/app/src/main/java/ru/whoame/recogniser/utils/StringArgsUtils.kt
+++ b/app/src/main/java/ru/whoame/recogniser/utils/StringArgsUtils.kt
@@ -1,0 +1,36 @@
+package ru.whoame.recogniser.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+/**
+ * Resolves the [StringArgs] instance into a final, displayable [String].
+ *
+ * This function must be called within a `@Composable` context because it uses
+ * [stringResource] to resolve [ResourceArgs].
+ *
+ * @return The formatted [String].
+ **/
+@Composable
+fun StringArgs.format(): String = when (this) {
+  is ResourceArgs -> stringResource(resourceId, *args)
+  is CharSequenceArgs -> value.toString()
+}
+
+/**
+ * A convenience function to convert an string resource ID into a [ResourceArgs] instance.
+ *
+ * @param args The optional format arguments for the string resource.
+ *
+ * @return A [ResourceArgs] instance wrapping the resource ID and its arguments.
+ **/
+fun Int.toStringArgs(vararg args: Any): StringArgs = ResourceArgs(this, arrayOf(*args))
+
+/**
+ * A convenience function to convert any [CharSequence] into a [CharSequenceArgs] instance.
+ *
+ * This allows for a more fluent way of creating a [StringArgs] object from a raw string.
+ *
+ * @return A [CharSequenceArgs] instance wrapping this CharSequence.
+ **/
+fun CharSequence.toStringArgs(): StringArgs = CharSequenceArgs(this)

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,6 +10,7 @@
     <dimen name="folded_image_foreground_height">50dp</dimen>
 
     <dimen name="empty_icon_size">150dp</dimen>
+    <dimen name="delete_item_dialog_icon_size">100dp</dimen>
 
     <dimen name="recognised_object_lazy_column_medium_max_width">400dp</dimen>
     <dimen name="recognised_object_lazy_column_expanded_max_width">200dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,9 +3,13 @@
 
     <string name="app_name">Recogniser</string>
 
+    <!-- Common strings -->
+    <string name="default_error">Something went wrong</string>
+
     <!-- Common action -->
     <string name="action_cancel">Cancel</string>
     <string name="action_delete">Delete</string>
+    <string name="action_done">Done</string>
 
     <!-- Animation label -->
     <string name="shimmer_transition_label">Shimmer transition</string>
@@ -21,11 +25,12 @@
     <string name="recognised_object_list_title">Recognised items</string>
     <string name="recognised_object_list_empty_title">There\'s nothing here</string>
     <string name="recognised_object_list_empty_message">Recognise something first</string>
-    <string name="recognised_object_list_error_title">Something went wrong</string>
     <string name="recognised_object_list_error_message">Try reinstalling the application or deleting data</string>
 
     <!-- Delete recognised item dialog -->
     <string name="delete_recognised_item_dialog_title">Deleting a saved item</string>
     <string name="delete_recognised_item_dialog_text">You\'re about to delete \"%1$s\". Are you sure?</string>
+    <string name="delete_recognised_item_dialog_error_title">Deleting a saved item failed</string>
+    <string name="delete_recognised_item_dialog_success_title">Saved item deleted</string>
 
 </resources>


### PR DESCRIPTION
For the element deletion dialog, I implemented successful and error states and returned the result to the calling screen.
| Success state | Error state |
| :--: | :--: |
| <img width="1352" height="620" alt="image" src="https://github.com/user-attachments/assets/7e08db47-1f12-49e1-b81e-06bee70027b1" /> | <img width="1340" height="656" alt="image" src="https://github.com/user-attachments/assets/3279d764-62ff-4eff-8dc9-fab68582df24" /> |
